### PR TITLE
shards contract improvements from flow team

### DIFF
--- a/cadence/contracts/Shard.cdc
+++ b/cadence/contracts/Shard.cdc
@@ -36,7 +36,11 @@ pub contract Shard: NonFungibleToken {
         pub let splits: UInt8
 
         // The metadata for a Moment
-        pub let metadata: {String: String}
+        access(self) let metadata: {String: String}
+
+        pub fun getMetadata(): {String: String} {
+            return self.metadata
+        }
 
         init(influencerID: String, splits: UInt8, metadata: {String: String}) {
             pre {
@@ -72,7 +76,11 @@ pub contract Shard: NonFungibleToken {
         pub let sequence: UInt8
 
         // Stores all the metadata about the Clip as a string mapping
-        pub let metadata: {String: String}
+        access(self) let metadata: {String: String}
+
+        pub fun getMetadata(): {String: String} {
+            return self.metadata
+        }
 
         init(momentID: UInt32, sequence: UInt8, metadata: {String: String}) {
             pre {
@@ -249,12 +257,12 @@ pub contract Shard: NonFungibleToken {
 
     // Publicly get metadata for a given Moment ID
     pub fun getMomentMetadata(momentID: UInt32): {String: String}? {
-        return self.moments[momentID]?.metadata
+        return self.moments[momentID]?.getMetadata()
     }
 
     // Publicly get metadata for a given Clip ID
     pub fun getClipMetadata(clipID: UInt32): {String: String}? {
-        return self.clips[clipID]?.metadata
+        return self.clips[clipID]?.getMetadata()
     }
 
     // Publicly get all Clips
@@ -276,16 +284,16 @@ pub contract Shard: NonFungibleToken {
 
         // Create a Collection resource and save it to storage
         let collection <- create Collection()
-        self.account.save(<-collection, to: /storage/ShardCollection)
+        self.account.save(<-collection, to: /storage/EternalShardCollection)
 
         // Create an Admin resource and save it to storage
         let admin <- create Admin()
-        self.account.save(<-admin, to: /storage/ShardAdmin)
+        self.account.save(<-admin, to: /storage/EternalShardAdmin)
 
         // Create a public capability for the collection
         self.account.link<&{NonFungibleToken.CollectionPublic}>(
-            /public/ShardCollection,
-            target: /storage/ShardCollection
+            /public/EternalShardCollection,
+            target: /storage/EternalShardCollection
         )
 
         emit ContractInitialized()

--- a/cadence/contracts/Shard.cdc
+++ b/cadence/contracts/Shard.cdc
@@ -36,11 +36,7 @@ pub contract Shard: NonFungibleToken {
         pub let splits: UInt8
 
         // The metadata for a Moment
-        access(self) let metadata: {String: String}
-
-        pub fun getMetadata(): {String: String} {
-            return self.metadata
-        }
+        access(contract) let metadata: {String: String}
 
         init(influencerID: String, splits: UInt8, metadata: {String: String}) {
             pre {
@@ -76,11 +72,7 @@ pub contract Shard: NonFungibleToken {
         pub let sequence: UInt8
 
         // Stores all the metadata about the Clip as a string mapping
-        access(self) let metadata: {String: String}
-
-        pub fun getMetadata(): {String: String} {
-            return self.metadata
-        }
+        access(contract) let metadata: {String: String}
 
         init(momentID: UInt32, sequence: UInt8, metadata: {String: String}) {
             pre {
@@ -257,12 +249,12 @@ pub contract Shard: NonFungibleToken {
 
     // Publicly get metadata for a given Moment ID
     pub fun getMomentMetadata(momentID: UInt32): {String: String}? {
-        return self.moments[momentID]?.getMetadata()
+        return self.moments[momentID]?.metadata
     }
 
     // Publicly get metadata for a given Clip ID
     pub fun getClipMetadata(clipID: UInt32): {String: String}? {
-        return self.clips[clipID]?.getMetadata()
+        return self.clips[clipID]?.metadata
     }
 
     // Publicly get all Clips

--- a/cadence/transactions/create-clip.cdc
+++ b/cadence/transactions/create-clip.cdc
@@ -6,10 +6,10 @@ import Shard from 0xShard
 transaction(momentID: UInt32, sequence: UInt8, metadata: {String: String}) {
     let minter: &Shard.Admin
     prepare(signer: AuthAccount) {
-        self.minter = signer.borrow<&Shard.Admin>(from: /storage/ShardAdmin)
+        self.minter = signer.borrow<&Shard.Admin>(from: /storage/EternalShardAdmin)
             ?? panic("Could not borrow a reference to the Shard minter")
     }
     execute {
-        self.minter.createClip(momentID: momentID, sequence: seq, metadata: metadata)
+        self.minter.createClip(momentID: momentID, sequence: sequence, metadata: metadata)
     }
 }

--- a/cadence/transactions/create-collection.cdc
+++ b/cadence/transactions/create-collection.cdc
@@ -6,14 +6,14 @@ import Shard from 0xShard
 
 transaction {
     prepare(acct: AuthAccount) {
-        if acct.borrow<&Shard.Collection>(from: /storage/ShardCollection) != nil {
+        if acct.borrow<&Shard.Collection>(from: /storage/EternalShardCollection) != nil {
             return
         }
         let collection <- Shard.createEmptyCollection()
-        acct.save(<-collection, to: /storage/ShardCollection)
+        acct.save(<-collection, to: /storage/EternalShardCollection)
         acct.link<&{NonFungibleToken.CollectionPublic}>(
-            /public/ShardCollection,
-            target: /storage/ShardCollection
+            /public/EternalShardCollection,
+            target: /storage/EternalShardCollection
         )
     }
 }

--- a/cadence/transactions/create-moment.cdc
+++ b/cadence/transactions/create-moment.cdc
@@ -6,7 +6,7 @@ import Shard from 0xShard
 transaction(influencerID: String, splits: UInt8, metadata: {String: String}) {
     let minter: &Shard.Admin
     prepare(signer: AuthAccount) {
-        self.minter = signer.borrow<&Shard.Admin>(from: /storage/ShardAdmin)
+        self.minter = signer.borrow<&Shard.Admin>(from: /storage/EternalShardAdmin)
             ?? panic("Could not borrow a reference to the Shard minter")
     }
     execute {

--- a/cadence/transactions/mint-batch.cdc
+++ b/cadence/transactions/mint-batch.cdc
@@ -7,12 +7,12 @@ import Shard from 0xShard
 transaction(recipient: Address, clipID: UInt32, quantity: UInt64) {
     let minter: &Shard.Admin
     prepare(signer: AuthAccount) {
-        self.minter = signer.borrow<&Shard.Admin>(from: /storage/ShardAdmin)
+        self.minter = signer.borrow<&Shard.Admin>(from: /storage/EternalShardAdmin)
             ?? panic("Could not borrow a reference to the Shard minter")
     }
     execute {
         let receiver = getAccount(recipient)
-            .getCapability(/public/ShardCollection)
+            .getCapability(/public/EternalShardCollection)
             .borrow<&{NonFungibleToken.CollectionPublic}>()
             ?? panic("Could not get receiver reference to the Shard Collection")
         self.minter.batchMintNFT(recipient: receiver, clipID: clipID, quantity: quantity)

--- a/cadence/transactions/mint.cdc
+++ b/cadence/transactions/mint.cdc
@@ -8,12 +8,12 @@ import Shard from 0xShard
 transaction(recipient: Address, clipID: UInt32) {
     let minter: &Shard.Admin
     prepare(signer: AuthAccount) {
-        self.minter = signer.borrow<&Shard.Admin>(from: /storage/ShardAdmin)
+        self.minter = signer.borrow<&Shard.Admin>(from: /storage/EternalShardAdmin)
             ?? panic("Could not borrow a reference to the Shard minter")
     }
     execute {
         let receiver = getAccount(recipient)
-            .getCapability(/public/ShardCollection)
+            .getCapability(/public/EternalShardCollection)
             .borrow<&{NonFungibleToken.CollectionPublic}>()
             ?? panic("Could not get receiver reference to the Shard Collection")
         self.minter.mintNFT(recipient: receiver, clipID: clipID)

--- a/cadence/transactions/transfer.cdc
+++ b/cadence/transactions/transfer.cdc
@@ -7,9 +7,9 @@ import Shard from 0xShard
 transaction(recipient: Address, withdrawID: UInt64) {
     prepare(acct: AuthAccount) {
         let recipient = getAccount(recipient)
-        let collectionRef = acct.borrow<&Shard.Collection>(from: /storage/ShardCollection)
+        let collectionRef = acct.borrow<&Shard.Collection>(from: /storage/EternalShardCollection)
             ?? panic("Could not borrow a reference to the owner's collection")
-        let depositRef = recipient.getCapability(/public/ShardCollection)
+        let depositRef = recipient.getCapability(/public/EternalShardCollection)
             .borrow<&{NonFungibleToken.CollectionPublic}>()
             ?? panic("Could not borrow a reference to the receiver's collection")
         let nft <- collectionRef.withdraw(withdrawID: withdrawID)

--- a/tests/create-clip.js
+++ b/tests/create-clip.js
@@ -14,7 +14,7 @@ const createClip = async (operator, momentID, sequence, metadataURI) => {
       transaction(momentID: UInt32, sequence: UInt8, metadata: {String: String}) {
           let minter: &Shard.Admin
           prepare(signer: AuthAccount) {
-              self.minter = signer.borrow<&Shard.Admin>(from: /storage/ShardAdmin)
+              self.minter = signer.borrow<&Shard.Admin>(from: /storage/EternalShardAdmin)
                   ?? panic("Could not borrow a reference to the Shard minter")
           }
           execute {

--- a/tests/create-collection.js
+++ b/tests/create-collection.js
@@ -16,14 +16,14 @@ const createCollection = async (...signers) => {
     import Shard from ${Shard}
     transaction {
         prepare(acct: AuthAccount) {
-            if acct.borrow<&Shard.Collection>(from: /storage/ShardCollection) != nil {
+            if acct.borrow<&Shard.Collection>(from: /storage/EternalShardCollection) != nil {
                 return
             }
             let collection <- Shard.createEmptyCollection()
-            acct.save(<-collection, to: /storage/ShardCollection)
+            acct.save(<-collection, to: /storage/EternalShardCollection)
             acct.link<&{NonFungibleToken.CollectionPublic}>(
-                /public/ShardCollection,
-                target: /storage/ShardCollection
+                /public/EternalShardCollection,
+                target: /storage/EternalShardCollection
             )
         }
     }

--- a/tests/create-moment.js
+++ b/tests/create-moment.js
@@ -14,7 +14,7 @@ const createMoment = async (operator, influencerID, splits, metadataURI) => {
       transaction(influencerID: String, splits: UInt8, metadata: {String: String}) {
           let minter: &Shard.Admin
           prepare(signer: AuthAccount) {
-              self.minter = signer.borrow<&Shard.Admin>(from: /storage/ShardAdmin)
+              self.minter = signer.borrow<&Shard.Admin>(from: /storage/EternalShardAdmin)
                   ?? panic("Could not borrow a reference to the Shard minter")
           }
           execute {

--- a/tests/mint-batch-nft.js
+++ b/tests/mint-batch-nft.js
@@ -16,14 +16,14 @@ const mintBatch = async (from, to, clipID, quantity) => {
     transaction(recipient: Address, clipID: UInt32, quantity: UInt64) {
         let minter: &Shard.Admin
         prepare(signer: AuthAccount) {
-            self.minter = signer.borrow<&Shard.Admin>(from: /storage/ShardAdmin)
+            self.minter = signer.borrow<&Shard.Admin>(from: /storage/EternalShardAdmin)
                 ?? panic("Could not borrow a reference to the Shard minter")
         }
         execute {
             let receiver = getAccount(recipient)
-                .getCapability(/public/ShardCollection)
+                .getCapability(/public/EternalShardCollection)
                 .borrow<&{NonFungibleToken.CollectionPublic}>()
-                ?? panic("Could not get receiver reference to the Shard Collection")
+                ?? panic("Could not get receiver reference to the Shard collection")
             self.minter.batchMintNFT(recipient: receiver, clipID: clipID, quantity: quantity)
         }
     }

--- a/tests/mint-nft.js
+++ b/tests/mint-nft.js
@@ -16,12 +16,12 @@ const mint = async (from, to, clipID) => {
     transaction(recipient: Address, clipID: UInt32) {
         let minter: &Shard.Admin
         prepare(signer: AuthAccount) {
-            self.minter = signer.borrow<&Shard.Admin>(from: /storage/ShardAdmin)
+            self.minter = signer.borrow<&Shard.Admin>(from: /storage/EternalShardAdmin)
                 ?? panic("Could not borrow a reference to the Shard minter")
         }
         execute {
             let receiver = getAccount(recipient)
-                .getCapability(/public/ShardCollection)
+                .getCapability(/public/EternalShardCollection)
                 .borrow<&{NonFungibleToken.CollectionPublic}>()
                 ?? panic("Could not get receiver reference to the Shard Collection")
             self.minter.mintNFT(recipient: receiver, clipID: clipID)

--- a/tests/transfer-nft.js
+++ b/tests/transfer-nft.js
@@ -16,9 +16,9 @@ const transfer = async (operator, from, to) => {
         transaction(recipient: Address, withdrawID: UInt64) {
             prepare(acct: AuthAccount) {
                 let recipient = getAccount(recipient)
-                let collectionRef = acct.borrow<&Shard.Collection>(from: /storage/ShardCollection)
+                let collectionRef = acct.borrow<&Shard.Collection>(from: /storage/EternalShardCollection)
                     ?? panic("Could not borrow a reference to the owner's collection")
-                let depositRef = recipient.getCapability(/public/ShardCollection)
+                let depositRef = recipient.getCapability(/public/EternalShardCollection)
                     .borrow<&{NonFungibleToken.CollectionPublic}>()
                     ?? panic("Could not borrow a reference to the receiver's collection")
                 let nft <- collectionRef.withdraw(withdrawID: withdrawID)


### PR DESCRIPTION
> I would recommend making your metadata fields on lines 75 and 39 private and defining explicit getters and setters for them so that they can't be modified by anyone in the future: https://docs.onflow.org/cadence/anti-patterns/#array-or-dictionary-fields-should-be-private
 
>I would also recommend creating slightly more detailed path identifiers for your storage so you can reduce the risk of path collisions for your objects.